### PR TITLE
Corregido "Etiqueta de cierre php faltante" en CRUD.php

### DIFF
--- a/PHP/CRUD.php
+++ b/PHP/CRUD.php
@@ -197,3 +197,4 @@ switch ($action) {
         header("Location: admin.php");
         exit;
 }
+?>


### PR DESCRIPTION
Este error tal vez no afecte a la funcionalidad, pero es importante cerrar las etiquetas para evitar problemas