### PR TITLE
Retoques al header

### DIFF
--- a/CSS/header.css
+++ b/CSS/header.css
@@ -187,6 +187,8 @@ body.dark-mode .nav-links a.btn-admin:focus {
   color: #555; /* Color del icono más oscuro */
   box-shadow: 0 1px 4px rgba(0,0,0,0.05); /* Sombra sutil */
   transition: all 0.2s ease;
+  position: relative;
+  z-index: 1100;
 }
 
 .menu-toggle i {
@@ -225,6 +227,18 @@ body.dark-mode .nav-links a.btn-admin:focus {
 .nav-links a:active {
   background-color: rgba(46, 125, 50, 0.08); /* Efecto al presionar */
   border-radius: 8px;
+}
+
+.menu-toggle .close-icon {
+  display: none;
+}
+
+.menu-open .menu-toggle .fa-bars {
+  display: none;
+}
+
+.menu-open .menu-toggle .close-icon {
+  display: flex;
 }
 
 /* ------------------------ */
@@ -299,6 +313,26 @@ body.dark-mode .nav-links a.btn-admin:focus {
   
   .logo {
     display: none;
+  }
+
+  .encabezado {
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+  }
+
+  .logo-link {
+    margin: 0 auto;
+    justify-content: center;
+  }
+
+  .logo-img {
+    margin: 0 auto;
+  }
+
+  .menu-toggle {
+    margin-top: 10px;
+    margin-left: 0;
   }
 }
 

--- a/javaScript/mainpagejs.js
+++ b/javaScript/mainpagejs.js
@@ -29,6 +29,7 @@
     });
   });
 
+  /*
   // Alternar modo oscuro
   darkModeToggle.addEventListener('click', () => {
     const isDark = document.body.classList.toggle('dark-mode');
@@ -40,7 +41,7 @@
     const icon = darkModeToggle.querySelector('i');
     icon.classList.toggle('fa-moon', !isDark);
     icon.classList.toggle('fa-sun', isDark);
-  });
+  }); */
 
   /*Cargar pagina cuando las imagenes esenciales esten cargadas */
   const images = document.querySelectorAll(".high-priority");

--- a/resources/header.php
+++ b/resources/header.php
@@ -8,6 +8,7 @@
 
     <button class="menu-toggle" id="menu-toggle" aria-label="Abrir menú de navegación" aria-expanded="false" aria-controls="nav-links">
       <i class="fas fa-bars"></i>
+      <i class="fas fa-times close-icon"></i>
     </button>
 
     <nav class="nav-links" id="nav-links" role="navigation" aria-label="Menú principal">
@@ -24,6 +25,6 @@
     <i class="fas fa-search" aria-hidden="true"></i>
     <input id="buscar" type="text" placeholder="Busca una especie...">
   </form>
-<?php endif; ?>
+  <?php endif; ?>
 
-  </header>
+</header>


### PR DESCRIPTION
Se corrigió el error de que en pantallas pequeñas el menú se desplegaba, pero al desplegarse tapaba el botón para cerrar el menú.

Aprovechando esto, se colocó el logo en el medio en pantallas pequeñas.